### PR TITLE
Container size optimization for AutoGluon

### DIFF
--- a/autogluon/Dockerfile
+++ b/autogluon/Dockerfile
@@ -12,10 +12,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 FROM base as builder
 
 WORKDIR /builds
-
-WORKDIR /builds
 COPY requirements.txt /requirements.txt
-RUN pip install --prefix=/install -r /requirements.txt
+RUN pip --no-cache-dir install --upgrade --trusted-host pypi.org --trusted-host files.pythonhosted.org pip \
+ && pip --no-cache-dir install --upgrade wheel setuptools \
+ && pip --no-cache-dir install --prefix=/install -r /requirements.txt
 
 FROM base
 

--- a/autogluon/requirements.txt
+++ b/autogluon/requirements.txt
@@ -1,2 +1,7 @@
- pandas==1.3.3
- autogluon==0.3.1
+--find-links https://download.pytorch.org/whl/torch_stable.html
+torch==1.9.1+cpu
+torchvision==0.10.1+cpu
+pandas==1.3.3
+numpy==1.19.5
+pillow>=6.2.0
+autogluon.tabular[all]==0.3.1


### PR DESCRIPTION
1. Since GPUs are not used in the baselines, using CPU version of pytorch to reduce size of the containers (cuts ~50% of the container size)
2. Installing only `autogluon.tabular` because other modalities are not used [1].